### PR TITLE
Parsing Time String

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 tthp: src/main.c
-	gcc -Iinclude src/main.c src/database.c -o tthp -lsqlite3
+	gcc -Iinclude src/main.c src/database.c src/parser.c -o tthp -lsqlite3

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,1 +1,8 @@
 // parser.h TenThousandHoursProject TTHP [Created by DBTow]
+
+#ifndef PARSER_H
+#define PARSER_H
+
+int parse_time(const char *time_str);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "database.h"
+#include "parser.h"
 
 int main(int argc, char *argv[])
 {
@@ -24,6 +25,8 @@ int main(int argc, char *argv[])
 		printf("Argv[%d]: %s\n", i, argv[i]);
 	if (strcmp(argv[1], commands[0]) == 0) {
 		printf("Log command recognized\n");
+		int result = parse_time(argv[2]);
+		printf("Parsed %d seconds from '%s'\n", result, argv[2]);
 	}
 
 	return 0;

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,1 +1,18 @@
 // parser.c TenThousandHoursProject TTHP [Created by DBTow]
+
+#include <stdio.h>
+
+int parse_time(const char *time_str);
+
+int parse_time(const char *time_str)
+{
+	int hours;
+	int minutes;
+
+	int result = sscanf(time_str, "%dh %dm", &hours, &minutes);
+
+	int total_seconds = (hours * 3600) + (minutes * 60);
+
+	return total_seconds;
+}
+


### PR DESCRIPTION
In parser.c I added a function: parse_time
-It takes as a parameter a character string
-This character string will be taken from the cli argument (given by the user) and represent the amount of time the user spent working on a skill to be logged to the database

the parse_time function uses the sccanf to parse the character string looking to extract any decimal following the characters 'h' and 'm' and assign them to the variable hours and minutes.

These variables are then converted to seconds and totaled together with that total seconds value being returned.

In parser.h I added this parse_time function to be globally available. As well as appropriately linking parser.c and parser.h in the makefile.

In main.c I added logic to include this new function. (Linked the appropriate header file as well)
-After the "log" command has been recognized in argv[1] it then runs the parse_time function on argv[2] which should be a time string given by the user in the format "hm" ("1h30m" for example).
-For right now it simply prints the return value from the parse_time function but later will be inserted into the database