### PR TITLE
Updated database schema and initialization

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -20,25 +20,47 @@ int db_init() {
 		return 1;
 	}
 	
-	char *sql =
+	// Creating main time_entries table
+	const char *sql_time_entries =
 		"CREATE TABLE IF NOT EXISTS time_entries ("
-		"id INTEGER PRIMARY KEY, "
-		"seconds INTEGER, "
-		"category TEXT, "
-		"description TEXT"
+		"id INTEGER PRIMARY KEY AUTOINCREMENT, "
+		"seconds INTEGER NOT NULL, "
+		"category TEXT NOT NULL, "
+		"date TEXT NOT NULL DEFAULT (DATE('now'))"
 		");";
 
-	rc = sqlite3_exec(db, sql, 0, 0, &err_msg);
+	rc = sqlite3_exec(db, sql_time_entries, 0, 0, &err_msg);
 
 	if (rc != SQLITE_OK) {
-		fprintf(stderr, "SQL error: %s\n", err_msg);
+		fprintf(stderr, "SQL error (time entries table): %s\n", err_msg);
 
 		sqlite3_free(err_msg);
 		sqlite3_close(db);
 
 		return 1;
 	}
-	
+
+	// Creating descriptions table
+	const char *sql_descriptions = 
+		"CREATE TABLE IF NOT EXISTS descriptions ("
+		"id INTEGER PRIMARY KEY AUTOINCREMENT, "
+		"time_entry_id INTEGER NOT NULL, "
+		"comment TEXT NOT NULL,"
+		"FOREIGN KEY (time_entry_id) REFERENCES time_entries(id) "
+		"ON DELETE CASCADE"
+		");";
+
+	rc = sqlite3_exec(db, sql_descriptions, 0, 0, &err_msg);
+
+	if (rc != SQLITE_OK) {
+		fprintf(stderr, "SQL error (descriptions table): %s\n", err_msg);
+
+		sqlite3_free(err_msg);
+		sqlite3_close(db);
+
+		return 1;
+	}
+
 	sqlite3_close(db);
 	return 0;
 }


### PR DESCRIPTION
I decided to make some database design changes. Instead of having the description be multiple comments stuffed into one row we will have a separate table representing multiple rows of comments linked to the original time entries table via foreign key.

In database.c in the db_init() function is where we added the creation of the second table. It has as values an id (serving as the primary key) / a time_entry_id which serves as the foreign key to the main time_entries table referencing its (id) value / a comment field where the comments for the description will be stored as text.

-Set a clause on the second table to delete all the comment rows if the associated parent row ever gets deleted.

-Added a data field for the data in the main time_entries table. By default it will take the current date using DATE('now') but later on this can be set by the user to add data that was logged outside of the current date.