### PR TITLE
rewrote parse_time function

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1,18 +1,54 @@
 // parser.c TenThousandHoursProject TTHP [Created by DBTow]
 
 #include <stdio.h>
+#include <stdbool.h>
+#include <ctype.h>
 
-int parse_time(const char *time_str);
+int parse_time(const char *time_str) {
+	if (!time_str || *time_str == '\0') return -1;
 
-int parse_time(const char *time_str)
-{
-	int hours;
-	int minutes;
+	const char *p = time_str;
+	bool h_exists = false, m_exists = false, s_exists = false;
+	int total_seconds = 0;
+	int current_num = 0;
 
-	int result = sscanf(time_str, "%dh %dm", &hours, &minutes);
+	while(*p != '\0') {
+		if (!isdigit((unsigned char)*p)) return -1;
 
-	int total_seconds = (hours * 3600) + (minutes * 60);
+		while (isdigit((unsigned char)*p)) {
+			// Character to digit conversion
+			current_num = (current_num * 10) + (*p - '0');
+			p++;
+		}
+
+		if (*p == 'h') {
+			if (h_exists) return -1; // Duplicate prevention
+			h_exists = true;
+			total_seconds = total_seconds + (current_num * 3600);
+			current_num = 0;
+			p++;
+		}
+
+		else if (*p == 'm') {
+			if (m_exists) return -1;
+			m_exists = true;
+			total_seconds = total_seconds + (current_num * 60);
+			current_num = 0;
+			p++;
+		}
+
+		else if (*p == 's') {
+			if (s_exists) return -1;
+			s_exists = true;
+			total_seconds = total_seconds + current_num;
+			current_num = 0;
+			p++;
+		}
+
+		else {
+			return -1; // Error
+		}
+	}
 
 	return total_seconds;
 }
-


### PR DESCRIPTION
Rewrote the parse_time function located in parser.c:
-It functions similarly to how the valid_duration function in detectors.c works except it returns the integer value of total_seconds representing the duration of time given by the user or a negative 1 for error.

(YES I am aware of the redundancy of the code and will fix it later)
(I am starting to understand the meaning of "Parse don't validate")

I will be doing a lot of design changes as I go but for the time being I just want a minimum viable product.