### PR TITLE
parsing date functions

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -52,3 +52,73 @@ int parse_time(const char *time_str) {
 
 	return total_seconds;
 }
+
+bool valid_date(int year, int month, int day) {
+	// Check year range
+	// Acceptable years are from 2025 to 2100
+	if (year <= 2025 || year > 2100) return false;
+
+	// Check month range (1 - 12)
+	if (month < 1 || month > 12) return false;
+
+	// First day check
+	if (day < 1 || day > 31) return false;
+
+	// Days per month array (non-leap years)
+	// Starting from January at 31 days
+	int days_per_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+	// Adjust February days per month if it is a leap year
+	if (month == 2) {
+		bool is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+		if (is_leap) {
+			days_in_month[1] = 29;
+		}
+	}
+
+	// Advanced day check
+	if (day > days_in_month[month - 1]) return false;
+	
+	return true;
+}
+
+int parse_date(const char *date_str, char *output); {
+	if (!date_str || *date_str == '\0') return -1;
+
+	int month, day, year;
+	
+	// Check format MM/DD/YYYY
+	if (sscanf(date_str, "%d/%d/%d", &month, &day, &year) == 3) {
+		if (valid_date(year, month, day)) {
+			sprintf(output, "%04d-%02d-%02d", year, month, day);
+			return 0;
+		}
+	}
+	
+	// Check format YYYY/MM/DD
+	if (sscanf(date_str, "%d/%d/%d", &year, &month, &day) == 3) {
+		if (valid_date(year, month, day)) {
+			sprintf(output, "%04d-%02d-%02d", year, month, day);
+			return 0;
+		}
+	}
+	
+	// Check format MM-DD-YYYY
+	if (sscanf(date_str, "%d-%d-%d", &month, &day, &year) == 3) {
+		if (valid_date(year, month, day)) {
+			sprintf(output, "%04d-%02d-%02d", year, month, day);
+			return 0;
+		}
+	}
+
+	// Check format YYYY-MM-DD
+	if (sscanf(date_str, "%d-%d-%d", &year, &month, &day) == 3) {
+		if (valid_date(year, month, day)) {
+			sprintf(output, "%04d-%02d-%02d", year, month, day);
+			return 0;
+		}
+	}
+
+	// No valid date format was found
+	return -1;
+}


### PR DESCRIPTION
Added two new functions in parser.c: valid_date and parse_date

-valid_date takes three integers as parameters (year, month, day) and checks to see if these are valid numbers for a date (Only accepts years from 2025 to 2100)
-Returns a boolean true if the date is valid and false if not

-parse_date takes a character string (date_str provided by user) and output string as parameters.
-It checks the format and validity of the date using valid_date and sscanf()
(Acceptable formats are: MM/DD/YYYY YYYY/MM/DD MM-DD-YYYY YYYY-MM-DD)

Uses sprintf to store a uniformed output to the output string in
"%04d-%02d-%02d" format representing YYYY-MM-DD which is the official recommendation for dates for sqlite.
-TEXT as ISO 8601: YYYY-MM-DD