### PR TITLE
current date function / implementation

### DIFF
--- a/include/utilities.h
+++ b/include/utilities.h
@@ -1,8 +1,11 @@
-// utilities.h TenThousandHoursProject TTHP [Created by DBTow]
+// utilities.h tenThousandHoursProject TTHP [Created by DBTow]
 
 #ifndef UTILITIES_H
 #define UTILITIES_H
 
-int check_for_date(const char *date_string);
+#include <time.h> // (optional I think...)
+
+// Function that grabs the current data and formats it into YYYY-MM-DD output string
+void get_todays_date(char *output);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,8 @@
 #include <ctype.h>
 #include <string.h>
 
+#include "utilities.h" // header for get_todays_date function
+
 int parse_time(const char *time_str) {
 	if (!time_str || *time_str == '\0') return -1;
 
@@ -170,11 +172,10 @@ TimeEntry parse_log_arguments(int argc, char **argv) {
 		}
 	}
 
-	// If no date is given use the default date
+	// If no date is given default behavior is use the current date 
 	if (entry.date[0] == '\0') {
-		// get_current_date() function
+		get_todays_date(entry.date); // Function that grabs the current date [from utilities.c]
 	}
 
 	return entry;
-
 }

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -1,28 +1,15 @@
 // utilities.c tenThousandHoursProject [tthp] Created by DBTow
 
 #include <stdio.h>
-#include <string.h>
+#include <time.h>
 
-int check_for_date(const char *date_string);
-
-int check_for_date(const char *date_string)
-{
-	char *result;
-	char target_character1 = '-';
-	char target_character2 = '/';
-
-	result = strchr(date_string, target_character1);
-	if (result != NULL) {
-		printf("Character '%c' found in a command line argument.\n", target_character1);
-	}
-
-	result = strchr(date_string, target_character2);
-	if (result != NULL) {
-		printf("Character '%c' found in a command line argument.\n", target_character2);
-	}
-	else {
-		printf("There appears to be no date given in the command line argument\n");
-	}
-
-	return 0;
+// Function to grab the current date and format it into a YYYY-MM-DD output string
+void get_todays_date(char *output) {
+	time_t now = time(NULL); // Get current time
+	struct tm *t = localtime(&now); // Convert to local time
+	
+	sprintf(output, "%04d-%02d-%02d",
+			t->tm_year + 1900, // Add 1900 to get the actual year
+			t->tm_mon + 1, // Months are numbered from 0 to 11, so you add 1 to match
+			t->tm_mday);
 }


### PR DESCRIPTION
Updated utilties.h:
-removed redundant/old code
-made the new get_todays_date function globally available

In utilities.c:
-removed unnecessary code
-created a new function get_todays_date() it is void (returns nothing) but takes as a parameter an output string to modify. This is where the current date will output to.

Implemented get_todays_date() function into parser.c and included the relevant header file.
-At the end of the parsing_log_arguments loop if no date was given then the default
behavior is to use the current date (using get_todays_date function) and store it into the entry.date target buffer.