### PR TITLE
fixed date parsing bug

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -106,6 +106,7 @@ int parse_date(const char *date_str, char *output) {
 			sprintf(output, "%04d-%02d-%02d", year, month, day);
 			return 0;
 		}
+		return -2; // Date format recognized but an invalid date was given
 	}
 
 	//Check format MM-DD-YYYY or YYYY-MM-DD (dash separator)
@@ -124,6 +125,7 @@ int parse_date(const char *date_str, char *output) {
 			sprintf(output, "%04d-%02d-%02d", year, month, day);
 			return 0;
 		}
+		return -2; 
 	}
 	
 	// No valid date format was found
@@ -154,9 +156,15 @@ TimeEntry parse_log_arguments(int argc, char **argv) {
 
 		// Checking for a valid date format
 		char date_buffer[11];
-		if (parse_date(argv[i], date_buffer) == 0) {
+		int date_result = parse_date(argv[i], date_buffer);
+		if (date_result == 0) {
 			strcpy(entry.date, date_buffer);
 			continue;
+		} else if (date_result == -2) {
+			// Date format was recognized but an invalid date was given
+			fprintf(stderr, "Error: Date format recognized but invalid date given '%s'. Please use a valid date between 2025-2100.\n", argv[i]);
+			entry.seconds = -1; // Mark entry as invalid
+			return entry;
 		}
 
 		// Check for category (category = first non duration or date argument)


### PR DESCRIPTION
Noticed while testing the program that if you run an invalid date like "10/05/2020" (Invalid year) the program will not flag it as an error but instead interpret it as a category or comment. This is due to it passing the format check but not having any catch for invalid dates.

So in the parse_date function it now if valid_date is not true the function returns -2.

Then in parse_log_arguments we adjusted how the date checking works. We now grab the result of the parse_date() function and store it in an int variable date_result which we will run if checks on.
-If the result is 0... its a valid date copy it into the entry.date struct field
-If the result is -2... print an error saying date format recognized but invalid date given and then set the entry.seconds field = -1 (This essentially marks the entry as invalid) then returns the entry struct

In commands.c after the parse_command identifies the log command from argv[1] it then executes the function cmd_log. The cmd_log function has a check for entry.seconds < 0 and this is where the program formally exits with a return of 1 for an invalid date (but correct date format).