### PR TITLE
timer state control functions

### DIFF
--- a/data/timer_state
+++ b/data/timer_state
@@ -1,0 +1,5 @@
+state=running
+start_time=1700000000
+accumulated_time=4000
+pid=99999
+tmux_session=test_write_session

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,0 +1,29 @@
+// timer.h tenThousandHoursProject tthp [Created by DBTow]
+
+#ifndef TIMER_H
+#define TIMER_H
+
+#include <time.h>
+#include <stdbool.h> 
+
+// Path to the timer state file
+#define TIMER_STATE_PATH "data/timer_state"
+
+// Timer state struct
+typedef struct {
+	bool is_running; 		// 1 = running and 0 = not running
+	time_t start_time; 		// A Unix timestamp of when the timer was last started
+	int accumulated_time; 		// The amount of accumulated time counted 
+} TimerState;
+
+// Function declarations
+
+int timer_read_state(TimerState *state);
+
+int timer_write_state(const TimerState *state);
+
+bool timer_clear_state();
+
+int get_elapsed_time(const TimerState *state, char *buf, size_t len);
+
+#endif

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,0 +1,65 @@
+// timer.c tenThousandHoursProject tthp [Created by DBTow]
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "timer.h"
+
+int timer_read_state(TimerState *state) {
+	FILE *fp = fopen(TIMER_STATE_PATH, "r");
+	if (!fp) {
+		return false; // File doesn't exist
+	}
+
+	int running;
+	long start, accumulated;
+
+	int n = fscanf(f, "%d %ld %ld", &running, &start, &accumulated);
+	fclose(fp);
+
+	if (n != 3) return false;
+
+	state->is_running = (running == 1);
+	state->start_time = (time_t)start;
+	state->accumulated_time = (int)accumulated;
+
+	return true;
+
+}
+
+bool timer_write_state(const TimerState *state) {
+	FILE *fp = fopen(TIMER_STATE_PATH, "w");
+	if (!fp) {
+		return false;
+	}
+
+	fprintf(f, "%d %ld %d\n",
+			state->is_running ? 1 : 0,
+			(long)state->start_time,
+			state->accumulated_time
+		);
+
+
+	fclose(fp);
+	return true;
+}
+
+bool timer_clear_state() {
+	return unlink(TIMER_STATE_PATH) == 0;
+}
+
+int get_elapsed_time(const TimerState *state, char *buf, size_t len) {
+	time_t now = time(NULL);
+	int total = state->accumulated_time;
+
+	if (state->is_running) {
+		total += (int)(now - state->start_time);
+	}
+
+	int hours = total / 3600;
+	int minutes = (total % 3600) / 60;
+	int seconds = total % 60;
+
+	return snprintf(buf, len, "%02d:%02d:%02d", h, m, s);
+}


### PR DESCRIPTION
Added a new directory data/ this is where the timer_state file will exist.
-/data/timer_state is a simple text file where information related to our stopwatch timers will be read and written to.

Created a timers.h file:
-Defines the timer state file path
-Creates the timer state struct that holds the boolean is_running / the unix timestamp of the starting time of the stopwatch / and the integer amount of accumulated time of the stopwatch.
-It then declares the functions in timers.c

In the timers.c file there are four new functions:

timer_read_state() and timer_write_state() are fairly obvious they read and write to the timer_state file. 

timer_clear_state() deletes the timer_state file. This will be useful for the timer clear subcommand. Will help differentiate between completely new stopwatches and stopwatches that are paused.

int get_elapsed_time() writes the total amount of elapsed time in an HH:MM:SS format to a buffer. Useful for the LIVE time calculations and that character array will be what shows up in our tmux status bar (HOPEFULLY).