### PR TITLE
dynamic path resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 tthp: src/main.c
-	gcc -Iinclude src/main.c src/database.c src/parser.c  src/utilities.c src/commands.c src/timer.c -o tthp -lsqlite3
+	gcc -Iinclude src/main.c src/database.c src/parser.c  src/utilities.c src/commands.c src/timer.c src/paths.c -o tthp -lsqlite3

--- a/include/paths.h
+++ b/include/paths.h
@@ -1,0 +1,19 @@
+// paths.h tenThousandHoursProject tthp [Created by DBTow]
+
+#ifndef PATHS_H
+#define PATHS_H
+
+// Initialize the path system... Called once at program start
+// Returns 0 on succes, -1 on failure
+int paths_init(void);
+
+// Fetches the project root directory (Where the tthp executable is located)
+const char* paths_get_root(void);
+
+// Get the full path to the database file
+const char* paths_get_db(void);
+
+// Get the full path to the timer_state file
+const char* paths_get_timer_state(void);
+
+#endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -6,8 +6,6 @@
 #include <time.h>
 #include <stdbool.h> 
 
-// Path to the timer state file
-#define TIMER_STATE_PATH "/data/timer_state"
 
 // Timer state struct
 typedef struct {

--- a/src/database.c
+++ b/src/database.c
@@ -3,15 +3,19 @@
 #include <stdio.h>
 #include <sqlite3.h>
 
-#define DB_PATH "/database/tthp.db"
+#include "paths.h"
+
 
 int db_init(void);
 
 int db_init() {
+	// Build the database path
+	const char *db_path = paths_get_db();
+
 	sqlite3 *db;
 	char *err_msg = 0;
 
-	int rc = sqlite3_open(DB_PATH, &db);
+	int rc = sqlite3_open(db_path, &db);
 	
 	if (rc != SQLITE_OK) {
 		fprintf(stderr, "Cannot open database %s\n", sqlite3_errmsg(db));

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 
 #include "database.h"
 #include "commands.h"
+#include "paths.h"
 
 int main(int argc, char *argv[])
 {
@@ -12,6 +13,12 @@ int main(int argc, char *argv[])
 	// Will eventually have a user menu if no arguments are given
 	if (argc < 2) {
 		printf("Please enter required arguments\n");
+		return 1;
+	}
+
+	// Initialize paths first
+	if (paths_init() != 0) {
+		fprintf(stderr, "Error: Could not determine program location\n");
 		return 1;
 	}
 

--- a/src/paths.c
+++ b/src/paths.c
@@ -1,0 +1,65 @@
+// paths.c tenThousandHoursProjects tthp [Created by DBTow]
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <libgen.h>
+#include <unistd.h>
+
+#include <mach-o/dyld.h> // macOS specific for: _NSGetExecutablePath()
+
+#include "paths.h"
+
+static char project_root[PATH_MAX];
+static char db_path[PATH_MAX];
+static char timer_state_path[PATH_MAX];
+static int paths_initialized = 0;
+
+int paths_init(void) {
+	if (paths_initialized) {
+		return 0;
+	}
+
+	char exe_path[PATH_MAX];
+	uint32_t size = sizeof(exe_path);
+
+	// Get executable path (macOS specific)
+	if (_NSGetExecutablePath(exe_path, &size) != 0) {
+		fprintf(stderr, "Error: Buffer too small for executable path\n");
+		return -1;
+	}
+
+	// Resolve any symlinks to get the real path
+	char real_path[PATH_MAX];
+	if (realpath(exe_path, real_path) == NULL) {
+		fprintf(stderr, "Error: Could not resolve executable path\n");
+		return -1;
+	}
+
+	// Get the directory containing the executable
+	char *exe_dir = dirname(real_path);
+	strncpy(project_root, exe_dir, PATH_MAX - 1);
+	project_root[PATH_MAX - 1] = '\0';
+
+	// Build the database path
+	snprintf(db_path, PATH_MAX, "%s/database/tthp.db", project_root);
+
+	// Build the timer_state path
+	snprintf(timer_state_path, PATH_MAX, "%s/data/timer_state", project_root);
+
+	paths_initialized = 1;
+	return 0;
+}
+
+const char* paths_get_root(void) {
+	return paths_initialized ? project_root : NULL;
+}
+
+const char* paths_get_db(void) {
+	return paths_initialized ? db_path : NULL;
+}
+
+const char* paths_get_timer_state(void) {
+	return paths_initialized ? timer_state_path : NULL;
+}

--- a/src/timer.c
+++ b/src/timer.c
@@ -6,9 +6,13 @@
 #include <unistd.h>
 
 #include "timer.h"
+#include "paths.h"
 
 bool timer_read_state(TimerState *state) {
-	FILE *fp = fopen(TIMER_STATE_PATH, "r");
+	// Build the path to the /data/timer_state file
+	const char *timer_state_path = paths_get_timer_state();
+
+	FILE *fp = fopen(timer_state_path, "r");
 	if (!fp) {
 		return false; // File doesn't exist
 	}
@@ -26,11 +30,12 @@ bool timer_read_state(TimerState *state) {
 	state->accumulated_time = (int)accumulated;
 
 	return true;
-
 }
 
 bool timer_write_state(const TimerState *state) {
-	FILE *fp = fopen(TIMER_STATE_PATH, "w");
+	const char *timer_state_path = paths_get_timer_state();
+
+	FILE *fp = fopen(timer_state_path, "w");
 	if (!fp) {
 		return false;
 	}
@@ -47,7 +52,11 @@ bool timer_write_state(const TimerState *state) {
 }
 
 bool timer_clear_state() {
-	return unlink(TIMER_STATE_PATH) == 0;
+	const char *timer_state_path = paths_get_timer_state();
+	if (!timer_state_path) {
+		return false;
+	}
+	return unlink(timer_state_path) == 0;
 }
 
 int get_elapsed_time(const TimerState *state, char *buf, size_t len) {


### PR DESCRIPTION
Previously the application used relative paths
(For example: ./database/tthp.db or ./data/timer_state)

However for my own personal use I want the active stopwatch to be shown in my Tmux status bar. Tmux fails to execute the program possibly because it starts from a different working directory... causing the timer status to not display in the Tmux status bar. The program still functions properly in the terminal but fails when Tmux tries to execute it.

To resolve this I implemented dynamic path resolution which solves the tmux integration problem.

Changes:
Updated makefile to include the new modules

Created the paths.h / path.c modules that manage paths
-Paths.c discovers and exposes filesystem paths relative to the program's executable at runtime
-Utilizes a macOS specific _NSGetExecutablePath() function to obtain the full path of the running binary.
-The module then resolves symlinks using realpath() to ensure an absolute path
-From the resolved executable location the parent directory is extracted with dirname() which becomes the project's runtime "root" directory. Using this root the module then constructs additional important paths.

[NEED to add more support for other operating systems]

Removed all instances of the hardcoded paths.

In main.c added a call to paths_init() and then subsequent getters return the computed paths after successful initialization. These computed paths are then used instead of previously hardcoded values in their respective functions.
